### PR TITLE
Explicit constructors

### DIFF
--- a/penguin/Exception.h
+++ b/penguin/Exception.h
@@ -13,8 +13,8 @@ namespace Penguin
 {
     struct Penguin_Export Timeout_Exception : public std::runtime_error
     {
-        Timeout_Exception(const std::string &what);
-        Timeout_Exception(const char *what);
+        explicit Timeout_Exception(const std::string &what);
+        explicit Timeout_Exception(const char *what);
     };
 } // namespace Penguin
 

--- a/penguin/Profiler.h
+++ b/penguin/Profiler.h
@@ -27,7 +27,7 @@ namespace Penguin
         typedef std::chrono::time_point<_clock_type>                        _time_point_type;
         typedef std::vector < _duration_type>                               _report_type;
 
-        Profiler(const std::string& id);
+        explicit Profiler(const std::string& id);
         virtual ~Profiler(void);
 
         static void dump_results(void);

--- a/penguin/Semaphore.h
+++ b/penguin/Semaphore.h
@@ -15,7 +15,7 @@ namespace Penguin
     class Penguin_Export Semaphore
     {
     public:
-        Semaphore(long permits = 0);
+        explicit Semaphore(long permits = 0);
         virtual ~Semaphore(void);
 
         void acquire(void);


### PR DESCRIPTION
Wasn't really looking to have conversion constructors available on some types. Made the constructors explicit to avoid unintended calling conventions.