### PR TITLE
Compile time string

### DIFF
--- a/penguin/Version.h
+++ b/penguin/Version.h
@@ -5,9 +5,12 @@
 #define PENGUIN_VERSION_H
 
 
+#include <string_view>
+
+
 namespace Penguin
 {
-#define PENGUIN_VERSION "0.1.0"
+    constexpr std::string_view = "0.1.0";
     constexpr long PENGUIN_MAJOR_VERSION = 0;
     constexpr long PENGUIN_MINOR_VERSION = 1;
     constexpr long PENGUIN_PATCH_VERSION = 0;


### PR DESCRIPTION
Removed #define for PENGUIN_VERSION and replaced with a constexpr.
Will be interesting to see if the build system compilers are recent enough versions to be able to build these.