### PR TITLE
Prefer the using keyword over typedef

### DIFF
--- a/penguin/Language.h
+++ b/penguin/Language.h
@@ -15,9 +15,9 @@
 namespace Penguin
 {
 #if defined(__GNUG__)
-    typedef std::experimental::string_view string_view;
+    using string_view = std::experimental::string_view;
 #elif defined(_MSC_VER)
-    typedef std::string_view string_view;
+    using string_view = std::string_view;
 #endif
 }
 

--- a/penguin/Monitor.h
+++ b/penguin/Monitor.h
@@ -17,9 +17,9 @@ namespace Penguin
     class Penguin_Export Monitor
     {
     public:
-        typedef std::mutex                      _mutex_type;
-        typedef std::condition_variable         _condition_variable_type;
-        typedef std::unique_lock<_mutex_type>   _guard_type;
+        using _mutex_type               = std::mutex;
+        using _condition_variable_type  = std::condition_variable;
+        using _guard_type               = std::unique_lock<_mutex_type>;
 
         Monitor(void);
         virtual ~Monitor(void);

--- a/penguin/Profiler.h
+++ b/penguin/Profiler.h
@@ -22,10 +22,10 @@ namespace Penguin
     class Penguin_Export Profiler
     {
     public:
-        typedef std::chrono::high_resolution_clock                          _clock_type;
-        typedef std::chrono::duration<double, PENGUIN_PROFILER_ACCURACY>    _duration_type;
-        typedef std::chrono::time_point<_clock_type>                        _time_point_type;
-        typedef std::vector < _duration_type>                               _report_type;
+        using _clock_type       = std::chrono::high_resolution_clock;
+        using _duration_type    = std::chrono::duration<double, PENGUIN_PROFILER_ACCURACY>;
+        using _time_point_type  = std::chrono::time_point<_clock_type>;
+        using _report_type      = std::vector<_duration_type>;
 
         explicit Profiler(const std::string& id);
         virtual ~Profiler(void);

--- a/samples/DirectX12/Sample_DirectX12.cpp
+++ b/samples/DirectX12/Sample_DirectX12.cpp
@@ -12,12 +12,12 @@
 
 namespace
 {
-    typedef Microsoft::WRL::ComPtr<IDXGIAdapter1>                                   _base_adapter_type;
-    typedef Microsoft::WRL::ComPtr<IDXGIOutput>                                     _base_output_type;
-    typedef std::tuple<_base_output_type, DXGI_OUTPUT_DESC>                         _output_type;
-    typedef std::vector<_output_type>                                               _output_list_type;
-    typedef std::tuple<_base_adapter_type, DXGI_ADAPTER_DESC1, _output_list_type>   _adapter_type;
-    typedef std::vector<_adapter_type>                                              _adapter_list_type;
+    using _base_adapter_type    = Microsoft::WRL::ComPtr<IDXGIAdapter1>;
+    using _base_output_type     = Microsoft::WRL::ComPtr<IDXGIOutput>;
+    using _output_type          = std::tuple<_base_output_type, DXGI_OUTPUT_DESC>;
+    using _output_list_type     = std::vector<_output_type>;
+    using _adapter_type         = std::tuple<_base_adapter_type, DXGI_ADAPTER_DESC1, _output_list_type>;
+    using _adapter_list_type    = std::vector<_adapter_type>;
 
 
     void print_adapter_and_output_information(const _adapter_list_type& adapter_list)


### PR DESCRIPTION
Shifted to preferring the using keyword for type aliases as it also supports aliases for templates in a consistent looking declaration.