### PR TITLE
Fix for Penguin::Timer using GCC and Clang

### DIFF
--- a/penguin/Timer.h
+++ b/penguin/Timer.h
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <stdexcept>
 
 
 namespace Penguin


### PR DESCRIPTION
Added <stdexcept> for GCC and Clang builds